### PR TITLE
bug fix proposal (issue #26)

### DIFF
--- a/src/Converter.js
+++ b/src/Converter.js
@@ -943,8 +943,8 @@ var MEI2VF = ( function(m2v, VF, $, undefined) {
         var me = this, refLocationIndex;
         // check if there's an unresolved TStamp2 reference to this location
         // (measure, staff, layer):
-        if (!measure_n)
-          throw new m2v.RUNTIME_ERROR('MEI2VF.RERR.me.extract_events:', '<measure> must have @n specified');
+        if (isNaN(measure_n))
+          throw new m2v.RUNTIME_ERROR('MEI2VF.RERR.extract_events', '<measure> must have @n specified');
         staff_n = staff_n || 1;
         refLocationIndex = measure_n + ':' + staff_n + ':' + ($(layer).attr('n') || '1');
         if (me.unresolvedTStamp2[refLocationIndex]) {

--- a/tests/TC.Hyphens.xml
+++ b/tests/TC.Hyphens.xml
@@ -21,7 +21,7 @@
 						</staffGrp>
 					</scoreDef>
 					<section>
-						<measure n="3" width="320" unit="px" right="dbl">
+						<measure n="0" width="320" unit="px" right="dbl">
 							<staff n="1">
 								<layer>
 									<note xml:id="n02" pname="c" oct="5" dur="4" dots="1" accid="n">
@@ -50,7 +50,7 @@
 								<staffDef n="1" clef.line="2" clef.shape="G" meter.count="6" meter.unit="4"/>
 							</staffGrp>
 						</scoreDef>
-						<measure n="4" unit="px">
+						<measure n="1" unit="px">
 							<staff n="1">
 								<layer>
 									<note xml:id="nb08" pname="c" oct="5" dur="1" accid="s">
@@ -71,7 +71,7 @@
 								</layer>
 							</staff>
 						</measure>
-						<measure n="5" unit="px">
+						<measure n="2" unit="px">
 							<staff n="1">
 								<layer>
 									<note xml:id="n14" pname="c" oct="5" dur="1" accid="s">
@@ -92,7 +92,7 @@
 								</layer>
 							</staff>
 						</measure>
-						<measure n="6">
+						<measure n="3">
 							<staff n="1">
 								<layer>
 									<note xml:id="n20" pname="b" oct="4" dur="4" dots="1">
@@ -119,7 +119,7 @@
 						</measure>
 						<sb/>
 						
-						<measure n="7" width="340">
+						<measure n="4" width="340">
 							<staff n="1">
 								<layer>
 									<note xml:id="n28" pname="c" accid="s" oct="5" dur="4" dots="1">
@@ -148,7 +148,7 @@
 							<dir startid="n34" place="above" type="pitch">cis</dir>
 							<dir startid="n35" place="above" type="pitch">e</dir>
 						</measure>
-						<measure n="8" right="dbl">
+						<measure n="5" right="dbl">
 							<staff n="1">
 								<layer>
 									<note xml:id="n08" pname="c" oct="5" dur="1" accid="s">
@@ -175,7 +175,7 @@
 								<staffDef n="1" clef.line="2" clef.shape="G" meter.count="4" meter.unit="4" meter.sym="cut"/>
 							</staffGrp>
 						</scoreDef>
-						<measure n="9">
+						<measure n="6">
 							<staff n="1">
 								<layer>
 									<note xml:id="n30" pname="g" accid="s" oct="5" dur="8">
@@ -194,7 +194,7 @@
 							</staff>
 						</measure>
 						
-						<measure n="10" width="120">
+						<measure n="7" width="120">
 							<staff n="1">
 								<layer>
 									<note xml:id="asd" dur="1" pname="f" accid="s" oct="5">
@@ -203,7 +203,7 @@
 								</layer>
 							</staff>
 						</measure>
-						<measure n="11" width="120">
+						<measure n="8" width="120">
 							<staff n="1">
 								<layer>
 									<note xml:id="asdf" dur="1" pname="e" accid="s" oct="5">
@@ -212,7 +212,7 @@
 							</staff>
 						</measure>
 						
-						<measure n="12" right="invis" width="70">
+						<measure n="9" right="invis" width="70">
 							<staff n="1">
 								<anchoredText ho="2">etc.</anchoredText>
 								<layer>


### PR DESCRIPTION
There's a line which tests if measure_n is falsy. I replaced it with an isNaN test and changed the hyphenation test case to cover measure number 0. This should work with mei2vf for now, but it might be necessary to eventually perform a larger reworking in order to change the measure_n datatype to allow values other than numbers, see #28.
